### PR TITLE
Updated link to Oscar Wagtail demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 
 ### Recipes
 
-- [Oscar Wagtail demo project](https://github.com/pgovers/oscar-wagtail-demo) - A Django recipe for integrating Oscar E-commerce into a Wagtail CMS application.
+- [Oscar Wagtail demo project](https://github.com/LUKKIEN/oscar-wagtail-demo) - A Django recipe for integrating Oscar E-commerce into a Wagtail CMS application.
 
 ### Presentations
 


### PR DESCRIPTION
We've moved the most up-2-date repository for Oscar Wagtail demo within the Lukkien namespace.
