### PR TITLE
Add Wagtail Experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Django Wagtail Feeds](https://github.com/chrisdev/django-wagtail-feeds) - Add support for RSS Feeds, Facebook Instant Articles and Apple News Publisher to your Wagtail CMS Projects.
 - [Wagtail Themes](https://github.com/moorinteractive/wagtail-themes) - Site-specific theme loader for Wagtail.
 - [wagtail-schema.org](https://github.com/takeflight/wagtail-schema.org) - Schema.org JSON-LD tags for Wagtail sites.
-- [Wagtail Experiments](https://github.com/torchbox/wagtail-experiments) – A/B testing for Wagtail
+- [Wagtail Experiments](https://github.com/torchbox/wagtail-experiments) – A/B testing for Wagtail.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Django Wagtail Feeds](https://github.com/chrisdev/django-wagtail-feeds) - Add support for RSS Feeds, Facebook Instant Articles and Apple News Publisher to your Wagtail CMS Projects.
 - [Wagtail Themes](https://github.com/moorinteractive/wagtail-themes) - Site-specific theme loader for Wagtail.
 - [wagtail-schema.org](https://github.com/takeflight/wagtail-schema.org) - Schema.org JSON-LD tags for Wagtail sites.
+- [Wagtail Experiments](https://github.com/torchbox/wagtail-experiments) – A/B testing for Wagtail
 
 ## Tools
 


### PR DESCRIPTION
https://github.com/torchbox/wagtail-experiments

Worth adding to the list because A/B testing is a popular practice in the CMS world – a Wagtail-aware tool is welcome.