### PR TITLE
Add article Wagtail: 2 Steps for Adding Pages Outside of the CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 
 - [Interactive 360 degree product views as a Wagtail streamfield block](http://www.djangopaths.com/interactive-360-degree-product-views-wagtail-streamfield-block/)
 - [Extending The Functionality of Email Forms in Wagtail](https://posts-by.lb.ee/dev-wagtail-extending-the-functionality-of-email-forms-232c8469ac97)
+- [Wagtail: 2 Steps for Adding Pages Outside of the CMS](https://www.caktusgroup.com/blog/2016/02/15/wagtail-2-steps-adding-pages-outside-cms/)
 
 ### Recipes
 


### PR DESCRIPTION
https://www.caktusgroup.com/blog/2016/02/15/wagtail-2-steps-adding-pages-outside-cms/

taken from https://github.com/mobolic/wagtail/blob/master/docs/advanced_topics/third_party_tutorials.rst