### PR TITLE
Add new open-source Wagtail sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [NHS.UK Content Store](https://github.com/nhsuk/nhsuk-content-store) – NHS.UK content store and editing app.
 - [dev.hel.fi](https://github.com/City-of-Helsinki/devheldev) – City of Helsinki development site with Wagtail.
 - [Digital Helsinki](https://github.com/City-of-Helsinki/digihel) – City of Helsinki Digital Helsinki Wagtail CMS.
+- [Secure the News](https://github.com/freedomofpress/securethenews) – An automated scanner and web dashboard for tracking TLS deployment across news organizations.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [dev.hel.fi](https://github.com/City-of-Helsinki/devheldev) – City of Helsinki development site with Wagtail.
 - [Digital Helsinki](https://github.com/City-of-Helsinki/digihel) – City of Helsinki Digital Helsinki Wagtail CMS.
 - [Secure the News](https://github.com/freedomofpress/securethenews) – An automated scanner and web dashboard for tracking TLS deployment across news organizations.
+- [HackSoft](https://github.com/HackSoftware/hacksoft.io) – Website for HackSoft.
+- [HackConf](https://github.com/HackSoftware/hackconf.bg) – Website for the annual HackConf.
 
 ## Community
 


### PR DESCRIPTION
https://github.com/freedomofpress/securethenews
https://github.com/HackSoftware/hacksoft.io
https://github.com/HackSoftware/hackconf.bg

I love adding to this list of sites so here are three 💯.