### PR TITLE
Add django-oscar-wagtail module to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [wagtailinvoices](https://github.com/SableWalnut/wagtailinvoices) - A Wagtail module for creating invoices.
 - [wagtail-saleor](https://github.com/mirumee/wagtail-saleor) - An e-commerce application based on Wagtail and Satchless.
 - [longclaw](https://github.com/JamesRamm/longclaw) - A shop template for Wagtail CMS.
+- [django-oscar-wagtail](https://github.com/LabD/django-oscar-wagtail) - Wagtail integration for Oscar Commerce (or Oscar Commerce integration for Wagtail?)
 
 ### SEO and SMO
 


### PR DESCRIPTION
This project integrates the Wagtail CMS with Django Oscar for eCommerce. It
adds the following features:

- each Oscar category page can now be managed by the Wagtail CMS
- it is possible to add product lists to wagtail pages