### PR TITLE
Add Wagtail FilePreviews to Misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Sharing](https://github.com/cfpb/wagtail-sharing) – Easier sharing of Wagtail drafts.
 - [Wagtail Postgres Search Backend](https://github.com/leukeleu/wagtail-pg-search-backend) - PostgreSQL full text search backend for Wagtail CMS.
 - [Wagtail Gridder](https://github.com/wharton/wagtailgridder) - Grid card layout similar to Google image search results, with an expanded area for card details.
+- [Wagtail FilePreviews](https://github.com/filepreviews/wagtail-filepreviews) - Extend Wagtail's Documents with image previews and metadata from FilePreviews.io
 
 ## Tools
 


### PR DESCRIPTION
Adds https://github.com/filepreviews/wagtail-filepreviews under the Misc section. Is there a another section that suits better something like this or is Misc fine?