### PR TITLE
Add wagtail-inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail SVGmap](https://github.com/City-of-Helsinki/wagtail-svgmap) - ImageMap functionality for Wagtail through inline SVGs.
 - [Wagtail ClearStream](https://github.com/heymonkeyriot/wagtailclearstream) - An app to make Wagtail's StreamField more modular.
 - [UWKM Streamfields](https://github.com/UWKM/uwkm_streamfields) – A basic set of Wagtail Streamfields for fun and profit.
+- [wagtail-inventory](https://github.com/cfpb/wagtail-inventory) - Search Wagtail pages by the StreamField blocks they contain.
 
 ### Static site generation
 


### PR DESCRIPTION
This change adds https://github.com/cfpb/wagtail-inventory as a new tool under the "Streamfield" section.