### PR TITLE
Require contributions to only use "Wagtail" instead of "Wagtail CMS" when referring to the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ Please ensure your pull request adheres to the following guidelines:
 - Link to the GitHub repo, not pypi.
 - Keep descriptions short and simple, but descriptive.
 - Start the description with a capital and end with a full stop/period.
-- Check your spelling and grammar. "Wagtail" should be written with a capital W.
+- Check your spelling and grammar.
+- Wagtail should be referred to as "Wagtail" instead of "Wagtail CMS", with a capital W.
 - Make sure your text editor is set to remove trailing whitespace.
 - The pull request should have a useful title and include a link to the package and why it should be included.
 


### PR DESCRIPTION
I've seen the two alternative denominations quite a lot, probably used both myself, but the officially supported one is "Wagtail". We are already requiring contributions to use a capital W, the next logical step would be to require people to use the right name for the project.

Here are examples from the list that would need to be changed:

- Wagtail-Constance - django-constance integration for Wagtail ~CMS~.
- longclaw - A shop template for Wagtail ~CMS~.
- wagtailpolls - A plugin for adding polling capabilities to the Wagtail ~CMS~.

Examples that are not that clear-cut – but that doesn't seem too problematic:

- wagtailmenus - An extension for Torchbox's Wagtail CMS to help you manage and render multi-level navigation and simple flat menus in a consistent, flexible way.

I don't think we need people to entirely rewrite their articles / GitHub READMEs / etc, but at least the label in here would be a good start.

Thoughts very welcome.