### PR TITLE
Add ls.joyous

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,6 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Accessibility](https://github.com/takeflight/wagtail-accessibility) – A plugin to assist with accessibility when developing in Wagtail.
 - [Wagtail Factories](https://github.com/mvantellingen/wagtail-factories) - Factory boy classes for Wagtail.
 
-### Groupware
-
-- [Joyous](https://github.com/linuxsoftware/ls.joyous) - A calendar application for Wagtail.
-
 ### Misc
 
 - [Wagtail Plus](https://github.com/rfosterslo/wagtailplus) - Modular add-ons for Wagtail CMS.
@@ -157,6 +153,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Postgres Search Backend](https://github.com/leukeleu/wagtail-pg-search-backend) - PostgreSQL full text search backend for Wagtail CMS.
 - [Wagtail Gridder](https://github.com/wharton/wagtailgridder) - Grid card layout similar to Google image search results, with an expanded area for card details.
 - [Wagtail Condensed Inline Panel](https://github.com/wagtail/wagtail-condensedinlinepanel) - Drop-in replacement for Wagtail's InlinePanel suited for large number of inlines (collapsible with drag and drop support).
+- [Joyous](https://github.com/linuxsoftware/ls.joyous) - A calendar application for Wagtail.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
   - [Translations](#translations)
   - [Forms](#forms)
   - [Testing](#testing)
+  - [Groupware](#groupware)
   - [Misc](#misc)
 - [Tools](#tools)
 - [Resources](#resources)
@@ -141,6 +142,10 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [wagtail-linkchecker](https://github.com/takeflight/wagtail-linkchecker) - A tool to assist with finding broken links on your Wagtail site.
 - [Wagtail Accessibility](https://github.com/takeflight/wagtail-accessibility) – A plugin to assist with accessibility when developing in Wagtail.
 - [Wagtail Factories](https://github.com/mvantellingen/wagtail-factories) - Factory boy classes for Wagtail.
+
+### Groupware
+
+- [Joyous](https://github.com/linuxsoftware/ls.joyous) - A calendar application for Wagtail.
 
 ### Misc
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
   - [Translations](#translations)
   - [Forms](#forms)
   - [Testing](#testing)
-  - [Groupware](#groupware)
   - [Misc](#misc)
 - [Tools](#tools)
 - [Resources](#resources)


### PR DESCRIPTION
This adds https://github.com/linuxsoftware/ls.joyous (A calendar application for Wagtail) under a new category called Groupware.  No existing category other than Misc seemed appropriate.