### PR TITLE
Add link to PyPI Trove classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [GitHub repository](https://github.com/wagtail/wagtail)
 - [Twitter account](https://twitter.com/wagtailcms)
 - [Roadmap](https://github.com/wagtail/wagtail/projects/1)
+- [PyPI classifiers for Wagtail](https://pypi.org/pypi?%3Aaction=list_classifiers)
 - [Other resources](#resources)
 
 ## Apps


### PR DESCRIPTION
https://pypi.org/pypi?%3Aaction=list_classifiers

cc @chosak. See https://github.com/wagtail/wagtail/issues/4483

I wasn't sure where to put this link. Hopefully it will still make it discoverable, so people know those classifiers exist.

Ideally, we would be linking to some blog post explaining what the classifiers are for and how to use them.