### PR TITLE
Added wagtail-instance-selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail-Geo-Widget](https://github.com/Frojd/wagtail-geo-widget) - Google Maps widget for the GeoDjango PointField field in Wagtail.
 - [wagtail-markdown](https://github.com/torchbox/wagtail-markdown) - Markdown fields and blocks for Wagtail.
 - [wagtail-autocomplete](https://github.com/wagtail/wagtail-autocomplete) - Autocompleting choosers for `ForeignKey`, `ParentalKey`, and `ManyToMany` fields.
+- [wagtail-instance-selector](https://github.com/ixc/wagtail-instance-selector) - A `ForeignKey` widget to create and select related items. Similar to Django's `raw_id_fields`.
 
 ### StreamField
 


### PR DESCRIPTION
Hi,

This adds `wagtail-instance-selector`. It's a FK widget lib that we've had under heavy use for the past year or so, but have only just open-sourced. 

Cheers,
Mark.