### PR TITLE
Add Wagtail-Lazyimages to Media section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Alt Generator](https://github.com/marteinn/wagtail-alt-generator) - A module for generating image description and tags based on computer vision.
 - [Wagtail FilePreviews](https://github.com/filepreviews/wagtail-filepreviews) - Extend Wagtail's Documents with image previews and metadata from FilePreviews.io.
 - [Wagtail-Textract](https://github.com/fourdigits/wagtail_textract) - Make Wagtail search Documents contents (PDF, Excel and Word, etc.).
+- [Wagtail-Lazyimages](https://github.com/ptrck/wagtail-lazyimages) - A plugin that generates tiny blurry placeholder images for lazy loading Wagtail images medium.com style.
 
 ### Translations
 


### PR DESCRIPTION
Just created this package. Provides a template tag that generates tiny blurry placeholder images alongside wagtail images for lazy loading them in the front end.

https://github.com/ptrck/wagtail-lazyimages