### PR TITLE
Add wagtail-opengraph-image-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [wagtail-metadata](https://github.com/takeflight/wagtail-metadata) - A tool to assist with metadata for social media and search engines.
 - [wagtail-metadata-mixin](https://github.com/bashu/wagtail-metadata-mixin) - OpenGraph, Twitter Card and Google+ snippet tags for Wagtail CMS pages.
 - [wagtail-schema.org](https://github.com/takeflight/wagtail-schema.org) - Schema.org JSON-LD tags for Wagtail sites.
+- [wagtail-opengraph-image-generator](https://github.com/candylabshq/wagtail-opengraph-image-generator) - Assists you in automatically creating Open Graph images for your Wagtail pages.
 
 ### Analytics
 


### PR DESCRIPTION
A project to assist you in automatically creating Open Graph images for your Wagtail pages.
Repo: https://github.com/candylabshq/wagtail-opengraph-image-generator
Added in the SEO and SMO category.