### PR TITLE
Remove `Wagtail Plus` entry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 
 ### Misc
 
-- [Wagtail Plus](https://github.com/rfosterslo/wagtailplus) - Modular add-ons for Wagtail CMS.
 - [wagtailmenus](https://github.com/rkhleics/wagtailmenus) - An extension for Torchbox's Wagtail CMS to help you manage and render multi-level navigation and simple flat menus in a consistent, flexible way.
 - [Wagtail Error Pages](https://gitlab.com/alexgleason/wagtailerrorpages) - Pretty, smart, customizable error pages for Wagtail.
 - [Wagtail Themes](https://github.com/moorinteractive/wagtail-themes) - Site-specific theme loader for Wagtail.


### PR DESCRIPTION
Wagtail Plus source repository deleted https://github.com/rfosterslo/wagtailplus .
Remove the link to fix the build. https://github.com/springload/awesome-wagtail/runs/449297374?check_suite_focus=true