### PR TITLE
Added PythonEatsTail.com in Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [How to Prevent Users from Creating Pages by Type](https://timonweb.com/tutorials/prevent-users-from-creating-certain-page-types-in-wagtail-cms/)
 - [Drupal Front End WTF, Wagtail Front End FTW](https://medium.com/@kevinhowbrook/drupal-front-end-wtf-wagtail-front-end-ftw-17712628df3e) - Comparing Drupal and Wagtail Markup and approach to each CMS
 - [How to Create and Manage Menus of Wagtail application](https://www.accordbox.com/blog/wagtail-tutorial-12-how-create-and-manage-menus-wagtail-application/)
+- [PythonEatsTail](https://pythoneatstail.com) - Complete written and video tutorials to create a Wagtail site with multiple languages, authentication and more
 
 ### Recipes
 


### PR DESCRIPTION
The site pythoneatstail.com contains (at the moment) 32 written tutorials and 32 video tutorials plus a public Github page; I thought Articles would be the best place. Please let me know if you think otherwise.