### PR TITLE
Add Wagtail JotForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Simple Captcha](https://github.com/acarasimon96/wagtail-django-simple-captcha) - A self-hosted alternative to Wagtail ReCaptcha that easily integrates a [django-simple-captcha](https://github.com/mbi/django-simple-captcha) field into the Wagtail form builder.
 - [wagtailstreamforms](https://github.com/AccentDesign/wagtailstreamforms) - Build forms in Wagtail's admin for use in streamfields.
 - [wagtail-contact-reply](https://github.com/KalobTaulien/wagtail-contact-reply) - Reply directly to form submissions from the Wagtail admin
-- [Wagtail JotForm](https://github.com/kevinhowbrook/wagtail-jotform) - Embedable Jotform forms for Wagtail pages.
+- [Wagtail JotForm](https://github.com/kevinhowbrook/wagtail-jotform) - Embeddable Jotform forms for Wagtail pages.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Simple Captcha](https://github.com/acarasimon96/wagtail-django-simple-captcha) - A self-hosted alternative to Wagtail ReCaptcha that easily integrates a [django-simple-captcha](https://github.com/mbi/django-simple-captcha) field into the Wagtail form builder.
 - [wagtailstreamforms](https://github.com/AccentDesign/wagtailstreamforms) - Build forms in Wagtail's admin for use in streamfields.
 - [wagtail-contact-reply](https://github.com/KalobTaulien/wagtail-contact-reply) - Reply directly to form submissions from the Wagtail admin
+- [Wagtail JotForm](https://github.com/kevinhowbrook/wagtail-jotform) - Embedable Jotform forms for Wagtail pages.
 
 ### Testing
 


### PR DESCRIPTION
Embeddable Jotform forms for Wagtail pages.

Wagtail Jotform works by providing a new EmbeddedFormPage page type with a form choice field. Values for this form field are populated from the Jotform API.