### PR TITLE
Added 'wagtail-pdf-view' (=PDF rendering for pages + models) to MISC

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Resume](https://github.com/adinhodovic/wagtail-resume) – A Wagtail project made to simplify creation of resumes for developers.
 - [Wagtail Content Import](https://github.com/torchbox/wagtail-content-import) - Import content from Google Docs or Docx into StreamFields, using a customisable mapping system.
 - [Wagtail Trash](https://github.com/Frojd/wagtail-trash) - Will place pages in a trash can from where they can be restored instead of being permanently deleted.
+- [Wagtail PDF View](https://github.com/donhauser/wagtail-pdf) - Render Wagtail pages and models as PDF document using Weasyprint or LaTeX.
 
 ## Tools
 


### PR DESCRIPTION
Extended the list with [Wagtail PDF View](https://github.com/donhauser/wagtail-pdf).

The goal of [Wagtail PDF View](https://github.com/donhauser/wagtail-pdf) is to provide a flexible but easy to use way to render Wagtail pages and Django models as PDF.

In some aspects this module might be suited as replacement for [wagtailinvoices](https://github.com/SableWalnut/wagtailinvoices), which has not been maintained in the past 5 years.