### PR TITLE
Add Wagtail CLIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Image Import](https://github.com/jacobtoppm/wagtail-image-import) - A plugin for importing images from Google Drive. 
 - [Wagtail SVG](https://github.com/Aleksi44/wagtailsvg) - A Wagtail module for managing SVG files within the admin.
 - [Wagtail Makeup](https://github.com/kevinhowbrook/wagtail-makeup) - A plugin that replaces all your images with [Unsplash](https://unsplash.com/) images.
+- [Wagtail CLIP](https://github.com/MattSegal/wagtail-clip) - A module for searching the contents of Wagtail images with natural language queries.
 
 ### Translations
 


### PR DESCRIPTION
I'd like to add [Wagtail CLIP](https://github.com/MattSegal/wagtail-clip) a Django app for Wagtail, to this list in the "media" section. This app replaces the search functionality in the Wagtail admin images page  with a machine-learning based search algorithm that compares the semantics of the text query to the contents of the image. For example, searching for "a dog with a frisbee" should returns images that contain dogs with frisbees, dogs, frisbees, and maybe scenes of parks, picnics, sports etc.

The project is not unit tested, but has an [example implementation](https://github.com/MattSegal/wagtail-clip-example) which I have used to manually test the library and setup instructions.

Both the project and CLIP model are MIT licensed.

I think people with large, rich image libraries in their CMS will find this useful, for small-medium applications (1000s of images). The code, which is reasonably simple, demonstrates how to use vector similarity and could inspire more scalable aproaches to using semantic search integrated with Wagtail (ie 10k, 100k images).