### PR TITLE
e-commerce - add Django salesman

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [wagtailinvoices](https://github.com/SableWalnut/wagtailinvoices) - A Wagtail module for creating invoices.
 - [longclaw](https://github.com/JamesRamm/longclaw) - A shop template for Wagtail CMS.
 - [django-oscar-wagtail](https://github.com/LabD/django-oscar-wagtail) - Wagtail integration for Oscar Commerce (or Oscar Commerce integration for Wagtail?).
+- [django-salesman](https://github.com/dinoperovic/django-salesman) - Headless e-commerce framework for Django with Wagtail modeladmin integration.
 
 ### SEO and SMO
 


### PR DESCRIPTION
- a headless e-commerce system
- has built in Wagtail integration (data management through modeladmin)
- https://django-salesman.readthedocs.io/en/latest/reference/admin.html#wagtail-hooks