### PR TITLE
Add Wagtail, CCA & Caltech's user guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,9 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 ## For editors
 
 - [How Do I Wagtail?](https://foundation.mozilla.org/en/docs/how-do-i-wagtail/) - Mozilla's editor facing guide for how to use Wagtail's admin interface. Source for this hosted on [Mozilla's Github](https://github.com/mozilla/foundation.mozilla.org/tree/master/network-api/networkapi/wagtailpages)
+- [Wagtail Editor's manual](https://docs.wagtail.org/en/stable/editor_manual/index.html) - Wagtail documentation for editors
+- [CCA Wagtail Editor Portal](https://portal.cca.edu/help/wagtail-documentation/) - User facing documentation for Wagtail by California College of the Arts
+- [Caltech Wagtail Editor Portal](https://sites.caltech.edu/) - User facing documentation for Wagtail by Caltech
 
 ## Community
 


### PR DESCRIPTION
A great resource for those who want to build their own or learn how to use wagtail.
Also added Wagtail's one - even though this is part of the technical documentation, it would be good to direct link in this section.