### PR TITLE
Media - Add Wagtail Transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Rent Free Media](https://github.com/RentFreeMedia/rentfreemedia) - A media distribution framework built on Django and Wagtail. Premium / subscription-based publishing like Patreon or Substack.
 - [Wagtail CLIP](https://github.com/MattSegal/wagtail-clip) - A module for searching the contents of Wagtail images with natural language queries.
 - [Wagtail Stock Images](https://github.com/vicktornl/wagtail-stock-images) - Search stock images (e.g. via Unsplash) and save them to your Wagtail image library.
+- [Wagtail Transcription](https://github.com/LilJack118/wagtail-transcription) - Provides a field to automatically creates transcriptions from YouTube videos.
 
 ### Translations
 


### PR DESCRIPTION
I'd like to add [Wagtail Transcription](https://github.com/LilJack118/wagtail-transcription), to this list in the Media section. 
This app allows users to easily create transcription from YouTube videos. The transcription process is run by AssemblyAi so the package is very lightweight. The documentation specifies the setup process, basic usage, and customization guide. The project contains unit tests.