### PR TITLE
Add Wagtail Reusable Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [Wagtail Blocks](https://github.com/ibrahimawadhamid/wagtail_blocks) - A Collection of awesome Wagtail CMS stream-field blocks and Charts.
 - [Wagtail Cache Block](https://github.com/AccordBox/wagtail_cache_block) - A templatetag which add HTML fragment cache to your StreamField block
 - [Wagtail UIKit Block](https://github.com/kpsaurus/wagtail-uikitblocks) - A collection of UIKit components that can be used as a Wagtail StreamField block.
+- [Wagtail Reusable Blocks](https://github.com/kkm-horikawa/wagtail-reusable-blocks) - Reusable content blocks with slot-based templating for flexible HTML layouts in the admin.
 
 ### Static site generation
 


### PR DESCRIPTION
## Addition

Add [Wagtail Reusable Blocks](https://github.com/kkm-horikawa/wagtail-reusable-blocks) to the StreamField section.

## Description

Reusable content blocks with slot-based templating for flexible HTML layouts in the admin.

## Why this package?

This package extends Wagtail's philosophy ("The best user interface for a programmer is usually a programming language") to the admin interface. It allows editors to:

- Create reusable content blocks shared across pages
- Define HTML layouts with fillable slots
- Inject dynamic content (images, rich text) into specific areas
- Make layout changes without code deployments

## Features

- Zero-code setup
- Slot-based templating (v0.2.0+)
- Revision history, Draft/Publish workflow, Locking (v0.3.0+)
- Nested blocks with circular reference detection
- Full test coverage

## Links

- [PyPI](https://pypi.org/project/wagtail-reusable-blocks/)
- [Django Packages](https://djangopackages.org/packages/p/wagtail-reusable-blocks/)
- [Documentation](https://github.com/kkm-horikawa/wagtail-reusable-blocks#readme)