### PR TITLE
Add wagtail-html-editor to Widgets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Awesome Wagtail [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38
 - [wagtail-multi-upload](https://github.com/spapas/wagtail-multi-upload) - allows uploading of multiple related images for a page.
 - [wagtail-color-panel](https://github.com/marteinn/wagtail-color-panel) - Introduces panels for selecting colors in Wagtail.
 - [Wagtail Ace Editor](https://github.com/Nigel2392/wagtail_ace_editor) - An IDE-like code editor right in your Wagtail admin.
+- [Wagtail HTML Editor](https://github.com/kkm-horikawa/wagtail-html-editor) - A CodeMirror 6-powered HTML editor for Wagtail with syntax highlighting, Emmet support, and dark mode.
 
 ### StreamField
 


### PR DESCRIPTION
## Summary

Adds [wagtail-html-editor](https://github.com/kkm-horikawa/wagtail-html-editor) to the Widgets section.

**wagtail-html-editor** is a CodeMirror 6-powered HTML editor for Wagtail that provides:
- Syntax highlighting for HTML, CSS, and JavaScript
- Emmet abbreviation support
- Dark/Light mode (follows Wagtail admin theme)
- Fullscreen editing mode
- Auto-closing tags and smart indentation

It serves as an enhanced replacement for Wagtail's built-in `RawHTMLBlock`.

- PyPI: https://pypi.org/project/wagtail-html-editor/
- Supports Wagtail 6.4, 7.0, 7.2