### PR TITLE
Add wagtail-unirate to StreamField section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ _You might also like [Awesome Django](https://github.com/wsvincent/awesome-djang
 
 - [wagtail-inventory](https://github.com/cfpb/wagtail-inventory) - Search Wagtail pages by the StreamField blocks they contain.
 - [Wagtail Code Block](https://github.com/wagtail-nest/wagtailcodeblock) - StreamField code blocks for the Wagtail CMS with real-time PrismJS Syntax Highlighting.
+- [wagtail-unirate](https://github.com/UniRate-API/wagtail-unirate) - Currency exchange rate blocks (`CurrencyRateBlock`, `CurrencyConversionBlock`, `MultiCurrencyPriceBlock`) and template tags powered by the UniRate API, with optional Django cache integration.
 
 ### Static site generation
 


### PR DESCRIPTION
Adds [wagtail-unirate](https://github.com/UniRate-API/wagtail-unirate) to the StreamField section.

**What it is:** A Wagtail/Django integration providing three StreamField blocks for displaying live currency exchange rates, plus six template tags and a Django-cache-aware API accessor. Published on [PyPI](https://pypi.org/project/wagtail-unirate/) with 34 mock tests and CI coverage across Python 3.10–3.13 × Django 4.2–5.2 × Wagtail 5.2–6.4.

**Disclosure:** I maintain wagtail-unirate and the UniRate API it connects to.
